### PR TITLE
Bugfix in core complete logic

### DIFF
--- a/click_shell/core.py
+++ b/click_shell/core.py
@@ -94,7 +94,7 @@ def get_complete(command):
         # Pulled from click._bashcomplete.do_complete, and adapted to work in this situation.
         args = shlex.split(line[:begidx])
 
-        ctx = resolve_ctx(command, command.name, args)
+        ctx = resolve_ctx(command, command.name, args[1:])
         if ctx is None:
             return []
 


### PR DESCRIPTION
Dropped the first argument being passed to resolve_ctx, being it the current command name itself