### PR TITLE
More clarification to command usage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Simply replace ``@click.group`` with ``@click_shell.shell`` on the root level co
     def my_app():
         pass
 
-    @my_app.command()
+    @my_app.command('the_command')
     def the_command():
         print 'the_command is running'
 
@@ -42,7 +42,8 @@ When run, you should expect an output like so:
 
     $ python my_app.py
     Starting my app...
-    my-app >
+    my-app > the_command
+    the_command is running
 
 
 .. note::


### PR DESCRIPTION
I've wasted about 1hr to figure out that you must specify command name inside `command` decorator if you need to access it from click-shell's shell