### PR TITLE
Fix broken autocompletion with click 7.0

### DIFF
--- a/click_shell/core.py
+++ b/click_shell/core.py
@@ -96,7 +96,7 @@ def get_complete(command):
         args = args[1:]
 
         # Then pass them on to the get_choices method that click uses for completion
-        return list(get_choices(command, command.name, args, text))
+        return [choice[0] if type(choice) is tuple else choice for choice in get_choices(command, command.name, args, text)]
 
     complete_.__name__ = 'complete_%s' % command.name
     return complete_


### PR DESCRIPTION
Since pallets/click@6c7276b get_choices returns a tuple of Arg/Opt-name and description.
This breaks autocomplete of readline.
This commit reverts this behaviour if get_choices returns a tuple.