### PR TITLE
Add handling for Windows "readline.__doc__ is NoneType" error.

### DIFF
--- a/click_shell/_cmd.py
+++ b/click_shell/_cmd.py
@@ -76,7 +76,7 @@ class ClickCmd(Cmd, object):
             readline.set_completer(self.complete)
             readline.set_completer_delims(' \n\t')
             to_parse = self.completekey + ': complete'
-            if 'libedit' in readline.__doc__:
+            if readline.__doc__ and 'libedit' in readline.__doc__:
                 # Special case for mac OSX
                 to_parse = 'bind ^I rl_complete'
             readline.parse_and_bind(to_parse)


### PR DESCRIPTION
For certain Windows installs, readline.__doc__ is None. Check before trying to search for the phrase "libedit" inside it.