### PR TITLE
Require click<8.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ SHORT_DESCRIPTION = "An extension to click that easily turns your click app into
 LONG_DESCRIPTION = read('README.rst')
 
 requirements = [
-    'click>=6.0',
+    'click>=6.0,<8.0.0',
 ]
 
 setup(


### PR DESCRIPTION
This new version of click breaks click-shell.