### PR TITLE
Support click >= 8.

### DIFF
--- a/click_shell/_cmd.py
+++ b/click_shell/_cmd.py
@@ -9,9 +9,8 @@ import os
 from cmd import Cmd
 
 import click
-from click._compat import raw_input as get_input
 
-from click_shell._compat import readline
+from click_shell._compat import readline, get_input
 
 
 class ClickCmd(Cmd, object):

--- a/click_shell/_compat.py
+++ b/click_shell/_compat.py
@@ -19,6 +19,14 @@ except ImportError:
     except ImportError:
         readline = None
 
+try:
+    from click._compat import raw_input as get_input
+except ImportError:
+    # If click._compat does not provide raw_input, it means we're
+    # dealing with click >= 8, which means we're under Python 3,
+    # so we can just use the standard input function.
+    get_input = input
+
 
 def get_method_type(func, obj):
     if PY2:
@@ -33,7 +41,13 @@ try:
 except ImportError:
 
     import click
-    from click._bashcomplete import resolve_ctx
+    try:
+        from click._bashcomplete import resolve_ctx
+    except ImportError:
+        from click.shell_completion import _resolve_context
+
+        def resolve_ctx(cli, prog_name, args):
+            return _resolve_context(cli, {}, prog_name, args)
 
     def get_choices(cli, prog_name, args, incomplete):
         """


### PR DESCRIPTION
Click 8 does no longer provide `raw_input` and has overhauled its shell completion code. This patch provides the necessary adjustments. Tested with both `click-7.1.2` and `click-8.0.1`.