### PR TITLE
feat(EXCEPTIONS): custom exceptions to override default error handling

### DIFF
--- a/click_shell/core.py
+++ b/click_shell/core.py
@@ -16,6 +16,7 @@ import click
 
 from ._compat import get_choices
 from .cmd import ClickCmd
+from . import exceptions
 
 logger = logging.getLogger(__name__)
 logger.addHandler(NullHandler())
@@ -48,6 +49,10 @@ def get_invoke(command: click.Command) -> Callable[[ClickCmd, str], bool]:
             # Catch this an return the code instead. All of click's help commands do a sys.exit(),
             # and that's not ideal when running in a shell.
             pass
+        except exceptions.ClickShellCleanExit as e:
+            e.clean_exit()
+        except exceptions.ClickShellUncleanExit as e:
+            e.unclean_exit()
         except Exception as e:
             traceback.print_exception(type(e), e, None)
             logger.warning(traceback.format_exc())

--- a/click_shell/exceptions.py
+++ b/click_shell/exceptions.py
@@ -1,0 +1,27 @@
+"""
+click_shell.exceptions
+
+Exceptions to allow overrides to the default click_shell error handling.
+"""
+
+import sys
+
+
+class ClickShellCleanExit(Exception):
+    """Raised by a command to exit the shell cleanly."""
+
+    def clean_exit(self):       # pylint: disable=no-self-use
+        sys.exit(0)
+
+
+class ClickShellUncleanExit(BaseException):
+    """Raised by a command to exit the shell with an error code.
+
+    Set the second exception arg to the error code you wish to use.
+    """
+    default_error_code = 1
+
+    def unclean_exit(self):
+        if len(self.args) > 1:
+            sys.exit(self.args[1])
+        sys.exit(self.default_error_code)

--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -1,0 +1,29 @@
+Custom Exceptions
+=================
+
+click-shell provides two custom exceptions (`ClickShellCleanExit` and `ClickShellUncleanExit`) to allow you terminate the shell under specific conditions.
+
+.. code-block:: python
+
+    import click
+    from click_shell import shell
+    from click_shell.exceptions import ClickShellCleanExit, ClickShellUncleanExit
+
+    @shell(prompt='my-app > ')
+    def my_app():
+        print('initializing the application...')
+
+    @my_app.command()
+    def cleanexit():
+        # Terminates the click-shell and returns exit code 0
+        ClickShellCleanExit("I am exiting the shell with an exit status of 0")
+
+    @my_app.command()
+    def uncleanexit():
+        # Terminates the click-shell and returns exit code 127
+        ClickShellUncleanExit("I am exiting the shell with a non-zero exit status", 127)
+
+    # more commands...
+
+    if __name__ == '__main__':
+        my_app()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,7 @@ Features
 
    install
    usage
+   exceptions
    changelog
    troubleshooting
    click-repl

--- a/requirements-python2.txt
+++ b/requirements-python2.txt
@@ -4,3 +4,4 @@ pylint
 pytest
 pytest-click<1.0
 pytest-cov
+mock

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,102 @@
+
+import pytest
+import click
+
+from click_shell.exceptions import ClickShellUncleanExit, ClickShellCleanExit
+from click_shell.core import Shell,  get_invoke
+
+
+try:
+    from unittest.mock import patch, Mock
+except ImportError:
+    from mock import patch, Mock
+
+
+@pytest.fixture
+def mock_cli_command():
+    shell = Shell()
+
+    @shell.command()
+    def mock_command():
+        pass
+
+    return mock_command
+
+
+@patch('click.Command.main')
+def test_unclean_exit_default_code(m_main, mock_cli_command):
+
+    expected_error_code = ClickShellUncleanExit.default_error_code
+
+    m_main.side_effect = ClickShellUncleanExit("Boom!")
+    invoke = get_invoke(mock_cli_command)
+
+    with pytest.raises(SystemExit) as exc:
+        invoke(Mock(), "mock args")
+
+    assert exc.value.args[0] == expected_error_code
+
+
+@patch('click.Command.main')
+def test_unclean_exit_specific_code(m_main, mock_cli_command):
+
+    expected_error_code = 127
+
+    m_main.side_effect = ClickShellUncleanExit("Boom!", expected_error_code)
+    invoke = get_invoke(mock_cli_command)
+
+    with pytest.raises(SystemExit) as exc:
+        invoke(Mock(), "mock args")
+
+    assert exc.value.args[0] == expected_error_code
+
+
+@patch('click.Command.main')
+def test_clean_exit(m_main, mock_cli_command):
+
+    m_main.side_effect = ClickShellCleanExit("Boom!")
+    invoke = get_invoke(mock_cli_command)
+
+    with pytest.raises(SystemExit) as exc:
+        invoke(Mock(), "mock args")
+
+    assert exc.value.args[0] == 0
+
+
+@patch('click.Command.main')
+def test_normal_sys_exit(m_main, mock_cli_command):
+
+    m_main.side_effect = SystemExit("Boom!")
+    invoke = get_invoke(mock_cli_command)
+
+    invoke(Mock(), "mock args")
+
+
+@patch('click.Command.main')
+def test_click_exception(m_main, mock_cli_command):
+
+    m_main.side_effect = click.ClickException("Boom!")
+    invoke = get_invoke(mock_cli_command)
+
+    invoke(Mock(), "mock args")
+
+
+@patch('click.Command.main')
+def test_click_abort(m_main, mock_cli_command):
+
+    m_main.side_effect = click.Abort("Boom!")
+    invoke = get_invoke(mock_cli_command)
+
+    invoke(Mock(), "mock args")
+
+
+@patch('click.Command.main')
+@patch('traceback.print_exception')
+def test_regular_exception(m_trace, m_main, mock_cli_command):
+
+    m_main.side_effect = Exception("Boom!")
+    invoke = get_invoke(mock_cli_command)
+
+    invoke(Mock(), "mock args")
+
+    m_trace.assert_called_once_with(Exception, m_main.side_effect, None)


### PR DESCRIPTION
I wanted to add some functionality that would let me override the default return to shell logic, in certain circumstances.
(ie. when I press CTRL-BREAK on a spawned ansible process managed by this CLI, I wanted to exit the app and halt everything.). 

I thought there might be other use cases for this, so I put together this feature.
I hope it's useful.

(Great package, thanks!)