### PR TITLE
Adding Linux-style command chaining

### DIFF
--- a/click_shell/__init__.py
+++ b/click_shell/__init__.py
@@ -15,4 +15,4 @@ __all__ = [
     '__version__',
 ]
 
-__version__ = "3.0.dev0"
+__version__ = "3.0.dev1"

--- a/click_shell/cmd.py
+++ b/click_shell/cmd.py
@@ -14,6 +14,66 @@ import click
 from ._compat import readline
 
 
+class CommandChainException(Exception):
+    pass
+
+
+class Command:
+    INITIAL = 'INITIAL'
+    AND = 'AND'
+    OR = 'OR'
+
+    def __init__(self, command: str, cmd_type: Union[AND, OR, INITIAL]):
+        self.text = command
+        self.cmd_type = cmd_type
+
+
+class CommandQueue(List):
+    """
+    ClickCmd expects a List, so we implement our own with parsing
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.queue = list()
+
+    def parse_line(self, *, line: str):
+        initial_command = True
+        for command in line.split("&&"):
+            command = command.strip()
+            if initial_command:
+                self.queue.append(Command(command=command, cmd_type=Command.INITIAL))
+                initial_command = False
+                continue
+            if '||' not in command:
+                self.queue.append(Command(command=command, cmd_type=Command.AND))
+            else:
+                first = True
+                for _command in command.split("||"):
+                    _command = _command.strip()
+                    if first:
+                        self.queue.append(Command(command=_command, cmd_type=Command.AND))
+                        first = False
+                        continue
+                    self.queue.append(Command(command=_command, cmd_type=Command.OR))
+
+    def pop(self, __index: int = ...):
+        return self.queue.pop(__index)
+
+    def flush(self) -> None:
+        """
+        Flushes out the queue by setting the property to an empty list
+        :return:
+        """
+        self.queue = list()
+
+    def __len__(self) -> int:
+        """
+        :return: int length of self.queue
+        """
+        return len(self.queue)
+
+
 class ClickCmd(Cmd):
     """
     A simple wrapper around the builtin python cmd module that:
@@ -56,6 +116,8 @@ class ClickCmd(Cmd):
         # Make the parent directory
         if not os.path.isdir(os.path.dirname(self.hist_file)):
             os.makedirs(os.path.dirname(self.hist_file))
+
+        self.cmdqueue = CommandQueue()
 
     def preloop(self):
         # read our history
@@ -108,9 +170,12 @@ class ClickCmd(Cmd):
                         click.echo(file=self._stdout)
                         click.echo('KeyboardInterrupt', file=self._stdout)
                         continue
-                line = self.precmd(line)
-                stop = self.onecmd(line)
-                stop = self.postcmd(stop, line)
+                try:
+                    line = self.precmd(line)
+                    stop = self.onecmd(line)
+                    stop = self.postcmd(stop, line)
+                except CommandChainException:
+                    self.cmdqueue.flush()
 
         finally:
             self.postloop()
@@ -119,6 +184,23 @@ class ClickCmd(Cmd):
                     readline.set_completer(self.old_completer)
                 if self.old_delims:
                     readline.set_completer_delims(self.old_delims)
+
+    def precmd(self, line: Union[str, Command]) -> str:
+        if isinstance(line, str):
+            if any([chain in line for chain in ["&&", "||"]]):
+                self.cmdqueue.parse_line(line=line)
+                line = self.cmdqueue.pop(0).text
+        if isinstance(line, Command):
+            # a non-zero return code followed by and AND-ed command
+            if self.ctx.return_code and line.cmd_type == Command.AND:  # noqa: return_code set in initial context
+                raise CommandChainException
+            # a zero return code followed by an OR-ed command
+            elif not self.ctx.return_code and line.cmd_type == Command.OR:  # noqa: return_code set in initial context
+                raise CommandChainException
+            else:
+                line = line.text
+
+        return line
 
     def get_prompt(self) -> Optional[str]:
         if callable(self.prompt):

--- a/click_shell/core.py
+++ b/click_shell/core.py
@@ -34,10 +34,11 @@ def get_invoke(command: click.Command) -> Callable[[ClickCmd, str], bool]:
 
     def invoke_(self: ClickCmd, arg: str):  # pylint: disable=unused-argument
         try:
-            command.main(args=shlex.split(arg),
-                         prog_name=command.name,
-                         standalone_mode=False,
-                         parent=self.ctx)
+            self.ctx.return_code = 0  # Set initial code
+            self.ctx.return_code = command.main(args=shlex.split(arg),
+                                                prog_name=command.name,
+                                                standalone_mode=False,
+                                                parent=self.ctx)
         except click.ClickException as e:
             # Show the error message
             e.show()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.fixture
+def cli_runner():
+    return CliRunner()


### PR DESCRIPTION
I've been using this package for some time in a work project where we need to make a custom shell for end-users to lock down everything, save for a few necessary commands, and to make in more Linux/Unix-like I added command chaining into my shell. 

It supports both *AND*  `&&` and *OR* `||` chains, and multiple combinations of each. I can write tests for them if desired. Although, I can tell you from usage that it works well. 

It does require the saving of the `return_code` of the command in the global core context, but that was a 2 line change in `core.py`.

I am happy to answer any other questions or provide a demo, if needed. 

Great project! Glad I can contribute something!